### PR TITLE
basic project page with dummy data

### DIFF
--- a/src/assets/projects_data.js
+++ b/src/assets/projects_data.js
@@ -1,0 +1,37 @@
+const TAGS = {
+  vue: 'Vue',
+  website: 'Website',
+  pwa: 'PWA',
+  api: 'API',
+  react: 'React',
+  db: 'database'
+}
+
+const projects_data = [
+  {
+    name: 'Landing Page',
+    screenshot: 'https://picsum.photos/300/200',
+    text: 'The landing page for our community.',
+    tags: [TAGS.vue, TAGS.website]
+  },
+  {
+    name: 'Something',
+    screenshot: 'https://picsum.photos/301/200',
+    text: 'A progressive web app created with react',
+    tags: [TAGS.react, TAGS.pwa]
+  },
+  {
+    name: 'And another',
+    screenshot: 'https://picsum.photos/300/201',
+    text: 'A database of our community members',
+    tags: [TAGS.db, TAGS.api]
+  },
+  {
+    name: 'Our fourth project',
+    screenshot: 'https://picsum.photos/299/200',
+    text: 'The landing page for our community.',
+    tags: [TAGS.vue, TAGS.website]
+  }
+]
+
+export default projects_data

--- a/src/router.js
+++ b/src/router.js
@@ -17,7 +17,13 @@ export default new Router({
       // route level code-splitting
       // this generates a separate chunk (about.[hash].js) for this route
       // which is lazy-loaded when the route is visited.
-      component: () => import(/* webpackChunkName: "about" */ './views/About.vue')
+      component: () =>
+        import(/* webpackChunkName: "about" */ './views/About.vue')
+    },
+    {
+      path: '/projects',
+      name: 'projects',
+      component: () => import('./views/Projects.vue')
     }
   ]
 })

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -1,17 +1,61 @@
-<!-- HTML Goes here -->
 <template>
-  
+  <section>
+    <h1>Projects</h1>
+    <p>Here are the projects that we have been working on:</p>
+    <main>
+      <div class="project" 
+        v-for="project in projects" 
+        :key="project.name">
+        <h2>{{project.name}}</h2>
+        <img 
+          :src="project.screenshot" 
+          alt="project screenshot">
+        <p>{{project.text}}</p>
+        <div class="tags">
+            <p class="tag"
+              v-for="tag in project.tags" 
+              :key="tag">
+              {{tag}}
+            </p>
+        </div>
+      </div>
+    </main>
+  </section>
 </template>
 
-<!-- JavaScript goes here -->
 <script>
+import data from '../assets/projects_data'
 export default {
-  name: 'projects'
+  name: 'projects',
+  data: function() {
+    return {
+      projects: data
+    }
+  }
 }
 </script>
 
-<!-- CSS goes here. 'scoped' attribute means the CSS will be applied to this component only. -->
+
 <style scoped>
+main {
+  display: flex;
+  flex-wrap: wrap;
+}
 
+.project {
+  flex: 1 1 33%;
+}
+
+.tags {
+  display: flex;
+  justify-content: center;
+}
+
+.tag {
+  background-color: #666;
+  color: white;
+  padding: 0.2em 1em;
+  border-radius: 20px;
+  margin: 0 0.5em;
+}
 </style>
-


### PR DESCRIPTION
Added projects route to router.js.
Basic project page set up with name of project, a screenshot, some text and tags to show what kind of project it is.
Created projects_data.js as a dummy data file to hold project info. Eventually we may pull the data in dynamically from an api or something.